### PR TITLE
Fixed duplicate header and empty header fields

### DIFF
--- a/ogrrd/CsvIterator/CsvIterator.php
+++ b/ogrrd/CsvIterator/CsvIterator.php
@@ -49,6 +49,7 @@ class CsvIterator extends \SplFileObject
      */
     public function useFirstRowAsHeader()
     {
+        $this->next();
         $this->setColumnNames($this->current(), true);
     }
 
@@ -58,10 +59,12 @@ class CsvIterator extends \SplFileObject
     public function current()
     {
         $row = parent::current();
+
         if ($this->names) {
             // skip first row if names are set by first row of file
             if ($this->firstRowUsedAsNames && $this->key() < 1) {
                 $this->next();
+                $row = parent::current();
             }
 
             $rowLength = count($row);

--- a/ogrrd/CsvIterator/CsvIterator.php
+++ b/ogrrd/CsvIterator/CsvIterator.php
@@ -29,6 +29,14 @@ class CsvIterator extends \SplFileObject
     }
 
     /**
+     * @return array
+     */
+    public function getColumnNames()
+    {
+        return $this->names;
+    }
+
+    /**
      * @param array $names
      * @param bool $firstRowUsedAsNames
      *
@@ -39,6 +47,12 @@ class CsvIterator extends \SplFileObject
         if ($firstRowUsedAsNames) {
             $this->firstRowUsedAsNames = true;
         }
+
+        array_walk($names, function (&$value, $key) {
+            if ($value === '') {
+                $value = "ROW_$key";
+            }
+        });
         $this->names = $names;
 
         return $this;


### PR DESCRIPTION
1) When `useFirstRowAsHeader()` is used, first iteration still returns header.

2) When you have CSV with some header fields empty, returning fields with keys as header labels won't work properly. I also added getter for better testing.